### PR TITLE
nvm: do not depend on `master`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/nvm/NvmWrapperUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/nvm/NvmWrapperUtil.java
@@ -119,7 +119,7 @@ public class NvmWrapperUtil {
   private Integer installNvm() throws IOException, InterruptedException {
     listener.getLogger().println("Installing nvm\n");
     FilePath installer = build.getWorkspace().child("nvm-installer");
-    installer.copyFrom(new URL("https://raw.github.com/creationix/nvm/master/install.sh"));
+    installer.copyFrom(new URL("https://raw.github.com/creationix/nvm/v0.33.0/install.sh"));
     installer.chmod(0755);
     ArgumentListBuilder args = new ArgumentListBuilder();
 


### PR DESCRIPTION
I'm the maintainer of `nvm`. The master branch is unstable, and I break it all the time, intentionally. Please do not depend on it; only depend on tagged releases.

Will fix https://github.com/creationix/nvm/pull/1381#issuecomment-272535291 / https://github.com/creationix/nvm/issues/1384