### PR TITLE
Correctly check for existence of .nvm folder on machine which runs the job

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/nvm/NvmWrapperUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/nvm/NvmWrapperUtil.java
@@ -10,7 +10,6 @@ import org.apache.log4j.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.nio.file.FileSystems;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -21,8 +20,6 @@ public class NvmWrapperUtil {
   private FilePath workspace;
   private Launcher launcher;
   private TaskListener listener;
-
-  private java.nio.file.FileSystem fs = FileSystems.getDefault();
 
   private List<String> nvmPaths = Arrays.asList(
     System.getProperty("user.home") + "/.nvm/nvm.sh",
@@ -112,8 +109,14 @@ public class NvmWrapperUtil {
 
   //**
   private Optional<String> getNvmPath() {
+    return nvmPaths.stream().filter((String str) -> {
+      Boolean exists = false;
+      try {
+        exists = workspace.child(str).exists();
+      } catch (IOException|InterruptedException e) {}
 
-    return nvmPaths.stream().filter((String str) -> fs.getPath(str).toFile().exists())
+      return exists;
+    })
       .findFirst();
 
   }


### PR DESCRIPTION
Without this change the plugin is always checking existence on the jenkins
primary server and not the secondary where the actual job is running.

Let me know about codestyle stuff. I'm not usually doing groovy/java.

I'm now successfully using a snapshot with this change in our jenkins installation with 4 secondary servers and it works fine.
With the latest published version the plugin installs nvm but then fails with "nvm not installed" if nvm hasn't been installed on the master.