### PR TITLE
Call workspace.mkdirs() to ensure workspace existance

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/nvm/NvmStep.java
+++ b/src/main/java/org/jenkinsci/plugins/nvm/NvmStep.java
@@ -117,6 +117,8 @@ public class NvmStep extends Step {
       final FilePath workspace = this.getContext().get(FilePath.class);
       final Launcher launcher = this.getContext().get(Launcher.class);
 
+      workspace.mkdirs();
+
       final NvmWrapperUtil wrapperUtil = new NvmWrapperUtil(workspace, launcher, launcher.getListener());
       final Map<String, String> npmEnvVars = wrapperUtil.getNpmEnvVars(this.version, this.nvmInstallURL, this.nvmNodeJsOrgMirror, this.nvmIoJsOrgMirror);
 


### PR DESCRIPTION
Create the job's workspace directory before running the job.

I'm not sure if this is the canonical way of doing it, but "it works for me", it's my first patch ever for a Jenkins plugin so improvements and suggestions are more than welcome.