### PR TITLE
Don't automatically use nvm once sourced

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/nvm/NvmWrapperUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/nvm/NvmWrapperUtil.java
@@ -58,7 +58,7 @@ public class NvmWrapperUtil {
     nvmSourceCmd.add("-c");
     nvmSourceCmd.add(
         "NVM_DIR=" + nvmDir +
-        " && source $NVM_DIR/nvm.sh "+
+        " && source $NVM_DIR/nvm.sh --no-use"+
         " && " + nodeMirrorBinaries +  " nvm install " + nodeVersion +
         " && nvm use " + nodeVersion + " && export > " + envFile );
 


### PR DESCRIPTION
In the event a project includes an .nvmrc file, we don't want to
immediately load the version specified. This is necessary, as nvm will
return an error code when it tries using a version that isn't currently
installed.