### PR TITLE
refactor: skip nvm install when possible

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/nvm/NvmWrapperUtil.java
+++ b/src/main/java/org/jenkinsci/plugins/nvm/NvmWrapperUtil.java
@@ -59,7 +59,8 @@ public class NvmWrapperUtil {
     nvmSourceCmd.add(
         "NVM_DIR=" + nvmDir +
         " && source $NVM_DIR/nvm.sh --no-use"+
-        " && " + nodeMirrorBinaries +  " nvm install " + nodeVersion +
+        " && " + "nvm which " + nodeVersion +
+        " || " + nodeMirrorBinaries +  " nvm install " + nodeVersion +
         " && nvm use " + nodeVersion + " && export > " + envFile );
 
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

nvm-wrapper will always try to use nvm install even when it has already been install, which may lead to error when fail to access remote nodejs site.
```
13:26:10  [some pipeline] $ bash -c "NVM_DIR=$HOME/.nvm && source $NVM_DIR/nvm.sh --no-use && NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/release nvm install v14.17.0 && nvm use v14.17.0 && export > env.txt"
13:25:09  Version 'v14.17.0' not found - try `nvm ls-remote` to browse available versions.
```
This problem can be simply fixed by adding a `nvm which` step before `nvm install`, and this is what this PR does.